### PR TITLE
feat: flags for custom preview server config

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ See the [docs][docs] or [typescript docs][tsdocs].
 [docs]: https://editor.dev/docs/
 [tsdocs]: https://editor.dev/api/connector/
 
+![Main build](https://github.com/blinkk/editor.dev/actions/workflows/push_main.yaml/badge.svg)
+
 ## Usage
 
 To use `editor.dev` with your local project run the following in your project directory (does not need to be added to your node dependencies):

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -1,6 +1,13 @@
 #!/usr/bin/env node
+
+/**
+ * CLI for serving project files for consumption by editor.dev.
+ *
+ * This command is made available as `npx @blinkk/editor.dev`.
+ */
+
 import {Command, Option} from 'commander';
-import {LocalApi} from './api/localApi';
+import {LocalApi, LocalApiOptions} from './api/localApi';
 import {LocalStorage} from './storage/localStorage';
 import {StorageManager} from './storage/storage';
 import cors from 'cors';
@@ -24,13 +31,22 @@ app.use(
   })
 );
 
-const program = new Command('npx @blinkk/editor.dev-ui.dev');
+const program = new Command('npx @blinkk/editor.dev');
 program.arguments('[path]');
 program.addOption(
   new Option(
     '-p, --port <number>',
     'port to serve the local API from.'
   ).default(PORT)
+);
+program.addOption(
+  new Option('--server <url>', 'preview server url for custom preview serving')
+);
+program.addOption(
+  new Option(
+    '--server-config <url>',
+    'preview server url for custom config json'
+  )
 );
 program.action((path, options) => {
   // Site files are managed by the storage manager.
@@ -39,8 +55,24 @@ program.action((path, options) => {
     storageCls: LocalStorage,
   });
 
+  const apiOptions: LocalApiOptions = {};
+
+  // Allow specifying a custom preview server for local development.
+  // @see https://editor.dev/api/ui/interfaces/editor_api.editorpreviewsettings.html
+  if (options.server) {
+    apiOptions.preview = {
+      baseUrl: options.server,
+    };
+    console.log('Using custom preview server:', options.server);
+
+    if (options.serverConfig) {
+      apiOptions.preview.configUrl = options.serverConfig;
+      console.log('Using custom preview server config:', options.serverConfig);
+    }
+  }
+
   // Running as a command uses the local storage and api.
-  const localApi = new LocalApi(storageManager);
+  const localApi = new LocalApi(storageManager, apiOptions);
   const port = options.port || PORT;
 
   app.use('/', localApi.apiRouter);


### PR DESCRIPTION
Allows the CLI to override the preview settings for the editor by specifying a url for the preview server.