### PR TITLE
fix: prefer amagaki projects over grow projects

### DIFF
--- a/src/ts/api/githubApi.ts
+++ b/src/ts/api/githubApi.ts
@@ -489,10 +489,11 @@ export class GithubApi implements ApiComponent {
     storage: ProjectTypeStorageComponent
   ): Promise<ProjectTypeComponent> {
     // Check for specific features of the supported projectTypes.
-    if (await GrowProjectType.canApply(storage)) {
-      return new GrowProjectType(storage);
-    } else if (await AmagakiProjectType.canApply(storage)) {
+    // Prefer amagaki over grow.
+    if (await AmagakiProjectType.canApply(storage)) {
       return new AmagakiProjectType(storage);
+    } else if (await GrowProjectType.canApply(storage)) {
+      return new GrowProjectType(storage);
     }
     // TODO: use generic projectType.
     throw new Error('Unable to determine projectType.');

--- a/src/ts/api/localApi.ts
+++ b/src/ts/api/localApi.ts
@@ -205,10 +205,11 @@ export class LocalApi implements ApiComponent {
     storage: ProjectTypeStorageComponent
   ): Promise<ProjectTypeComponent> {
     // Check for specific features of the supported projectTypes.
-    if (await GrowProjectType.canApply(storage)) {
-      return new GrowProjectType(storage);
-    } else if (await AmagakiProjectType.canApply(storage)) {
+    // Prefer amagaki over grow.
+    if (await AmagakiProjectType.canApply(storage)) {
       return new AmagakiProjectType(storage);
+    } else if (await GrowProjectType.canApply(storage)) {
+      return new GrowProjectType(storage);
     }
     // TODO: use generic projectType.
     throw new Error('Unable to determine projectType.');


### PR DESCRIPTION
When a project has a `podspec.yaml` and a `amagaki.ts/js` it should use the amagaki project type not grow.

See https://github.com/blinkk/editor.dev-ui/issues/120