### PR TITLE
fix: Auth cache not clearing after auth request.

### DIFF
--- a/src/ts/auth/githubAuth.ts
+++ b/src/ts/auth/githubAuth.ts
@@ -111,6 +111,10 @@ async function authenticateGitHub(
 
       // Only update datastore in the original request.
       let response: GHAuthAccessMeta | GHAuthError = await authMeta.promise;
+
+      // Clear out the auth cache after the request.
+      delete authCache[cacheKey];
+
       verifyAuthResponse(
         response,
         'Unable to confirm authentication with GitHub.'
@@ -137,6 +141,9 @@ async function authenticateGitHub(
     }
 
     const response: GHAuthAccessMeta | GHAuthError = await authMeta.promise;
+
+    // Clear out the auth cache after the request.
+    delete authCache[cacheKey];
 
     verifyAuthResponse(
       response,
@@ -168,6 +175,10 @@ async function authenticateGitHub(
 
       // Only update datastore with the original request.
       let response: GHAuthAccessMeta | GHAuthError = await authMeta.promise;
+
+      // Clear out the auth cache after the request.
+      delete authCache[cacheKey];
+
       verifyAuthResponse(
         response,
         'Unable to refresh authentication with GitHub.'


### PR DESCRIPTION
The auth cache is not being cleaned correctly after a request is complete. Either for success or failure. This gives stale auth responses when the server has been running long enough to need to get a refresh token, but there is no token available since it is using the old cached request.

fixes #50